### PR TITLE
feat: add composite primary key support

### DIFF
--- a/src/physical_plan/exec/sequential_union.rs
+++ b/src/physical_plan/exec/sequential_union.rs
@@ -18,7 +18,7 @@
 //! Sequential union execution plan that processes inputs without spawning tasks.
 //!
 //! This module provides [`SequentialUnionExec`], an alternative to DataFusion's
-//! [`UnionExec`] that reports a single partition and processes all input partitions
+//! [`UnionExec`](datafusion::physical_plan::union::UnionExec) that reports a single partition and processes all input partitions
 //! sequentially. This avoids the task spawning that occurs when `CoalescePartitionsExec`
 //! is inserted for multi-partition plans.
 
@@ -42,7 +42,7 @@ use futures::Stream;
 
 /// A union execution plan that processes all inputs sequentially in a single partition.
 ///
-/// Unlike DataFusion's [`UnionExec`] which reports N partitions for N inputs (causing
+/// Unlike DataFusion's [`UnionExec`](datafusion::physical_plan::union::UnionExec) which reports N partitions for N inputs (causing
 /// `CoalescePartitionsExec` to be inserted and spawn Tokio tasks), this operator
 /// always reports exactly 1 partition and chains all input partition streams sequentially.
 ///

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -198,7 +198,6 @@ pub trait IndexedTableProvider: TableProvider + Sync + Send {
 mod tests {
     use super::*;
     use crate::physical_plan::Index;
-    use crate::physical_plan::ROW_ID_COLUMN_NAME;
     use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
     use datafusion::catalog::Session;
     use datafusion::common::Statistics;
@@ -225,11 +224,7 @@ mod tests {
         }
 
         fn index_schema(&self) -> SchemaRef {
-            Arc::new(Schema::new(vec![Field::new(
-                ROW_ID_COLUMN_NAME,
-                DataType::UInt32,
-                false,
-            )]))
+            Arc::new(Schema::new(vec![Field::new("id", DataType::UInt32, false)]))
         }
 
         fn table_name(&self) -> &str {

--- a/src/types.rs
+++ b/src/types.rs
@@ -62,8 +62,8 @@ pub enum IndexFilter {
     /// A disjunction (OR) of multiple filter conditions across different indexes.
     ///
     /// This represents scenarios where any of several conditions can be satisfied.
-    /// The execution strategy unions results from all indexes and deduplicates to
-    /// ensure each row appears only once in the final result.
+    /// The execution strategy unions results from all indexes and deduplicates on
+    /// all primary key columns to ensure each row appears only once in the final result.
     Or(Vec<IndexFilter>),
 }
 

--- a/tests/common/composite_pk_fetcher.rs
+++ b/tests/common/composite_pk_fetcher.rs
@@ -1,0 +1,87 @@
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::arrow::array::{Array, Int32Array, StringArray, UInt64Array};
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::Result;
+use datafusion_index_provider::physical_plan::fetcher::RecordFetcher;
+
+pub struct CompositePkFetcher {
+    data: RecordBatch,
+}
+
+impl CompositePkFetcher {
+    pub fn new(data: RecordBatch) -> Self {
+        Self { data }
+    }
+}
+
+impl fmt::Debug for CompositePkFetcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CompositePkFetcher")
+    }
+}
+
+#[async_trait]
+impl RecordFetcher for CompositePkFetcher {
+    fn schema(&self) -> SchemaRef {
+        self.data.schema()
+    }
+
+    async fn fetch(&self, index_batch: RecordBatch) -> Result<RecordBatch> {
+        let req_tenants = index_batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let req_eids = index_batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap();
+
+        let data_tenants = self
+            .data
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let data_eids = self
+            .data
+            .column(1)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap();
+
+        let mut indices = Vec::new();
+        for i in 0..req_tenants.len() {
+            let req_t = req_tenants.value(i);
+            let req_e = req_eids.value(i);
+
+            for j in 0..data_tenants.len() {
+                if data_tenants.value(j) == req_t && data_eids.value(j) == req_e {
+                    indices.push(j as i32);
+                    break;
+                }
+            }
+        }
+
+        let indices_array = Int32Array::from(indices);
+        let new_columns: Result<Vec<Arc<dyn Array>>> = self
+            .data
+            .columns()
+            .iter()
+            .map(|col| {
+                Ok(Arc::new(datafusion::arrow::compute::take(
+                    col.as_ref(),
+                    &indices_array,
+                    None,
+                )?) as Arc<dyn Array>)
+            })
+            .collect();
+
+        Ok(RecordBatch::try_new(self.data.schema(), new_columns?)?)
+    }
+}

--- a/tests/common/composite_pk_provider.rs
+++ b/tests/common/composite_pk_provider.rs
@@ -1,0 +1,158 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::arrow::array::{Int32Array, StringArray, UInt64Array};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::catalog::Session;
+use datafusion::datasource::{TableProvider, TableType};
+use datafusion::error::Result;
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_common::DataFusionError;
+use datafusion_index_provider::physical_plan::create_index_schema;
+use datafusion_index_provider::physical_plan::exec::fetch::RecordFetchExec;
+use datafusion_index_provider::physical_plan::Index;
+use datafusion_index_provider::provider::IndexedTableProvider;
+use datafusion_index_provider::types::UnionMode;
+
+use super::composite_pk_age_index::CompositePkAgeIndex;
+use super::composite_pk_department_index::CompositePkDeptIndex;
+use super::composite_pk_fetcher::CompositePkFetcher;
+
+pub fn composite_pk_schema() -> SchemaRef {
+    create_index_schema([
+        Field::new("tenant_id", DataType::Utf8, false),
+        Field::new("employee_id", DataType::UInt64, false),
+    ])
+}
+
+/// A multi-tenant employee table with composite PK (tenant_id, employee_id)
+///
+/// | tenant_id | employee_id | name    | age | department  |
+/// |-----------|-------------|---------|-----|-------------|
+/// | acme      | 1           | Alice   | 25  | Engineering |
+/// | acme      | 2           | Bob     | 30  | Sales       |
+/// | acme      | 3           | Charlie | 35  | Marketing   |
+/// | globex    | 1           | David   | 28  | Engineering |
+/// | globex    | 2           | Eve     | 32  | Sales       |
+#[derive(Debug)]
+pub struct MultiTenantEmployeeProvider {
+    schema: SchemaRef,
+    age_index: Arc<CompositePkAgeIndex>,
+    dept_index: Arc<CompositePkDeptIndex>,
+    fetcher: Arc<CompositePkFetcher>,
+    union_mode: UnionMode,
+}
+
+impl Default for MultiTenantEmployeeProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MultiTenantEmployeeProvider {
+    pub fn new() -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("tenant_id", DataType::Utf8, false),
+            Field::new("employee_id", DataType::UInt64, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("age", DataType::Int32, false),
+            Field::new("department", DataType::Utf8, false),
+        ]));
+
+        let tenant_ids = StringArray::from(vec!["acme", "acme", "acme", "globex", "globex"]);
+        let employee_ids = UInt64Array::from(vec![1, 2, 3, 1, 2]);
+        let names = StringArray::from(vec!["Alice", "Bob", "Charlie", "David", "Eve"]);
+        let ages = Int32Array::from(vec![25, 30, 35, 28, 32]);
+        let departments = StringArray::from(vec![
+            "Engineering",
+            "Sales",
+            "Marketing",
+            "Engineering",
+            "Sales",
+        ]);
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(tenant_ids.clone()),
+                Arc::new(employee_ids.clone()),
+                Arc::new(names),
+                Arc::new(ages.clone()),
+                Arc::new(departments.clone()),
+            ],
+        )
+        .unwrap();
+
+        Self {
+            schema,
+            age_index: Arc::new(CompositePkAgeIndex::new(&ages, &tenant_ids, &employee_ids)),
+            dept_index: Arc::new(CompositePkDeptIndex::new(
+                &departments,
+                &tenant_ids,
+                &employee_ids,
+            )),
+            fetcher: Arc::new(CompositePkFetcher::new(batch)),
+            union_mode: UnionMode::Parallel,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn with_union_mode(mut self, mode: UnionMode) -> Self {
+        self.union_mode = mode;
+        self
+    }
+}
+
+#[async_trait]
+impl TableProvider for MultiTenantEmployeeProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        _projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let (indexed_filters, _remaining) = self.analyze_and_optimize_filters(filters)?;
+
+        Ok(Arc::new(RecordFetchExec::try_new(
+            indexed_filters,
+            limit,
+            self.fetcher.clone(),
+            self.schema.clone(),
+            self.union_mode,
+        )?))
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        self.supports_filters_index_pushdown(filters)
+    }
+}
+
+#[async_trait]
+impl IndexedTableProvider for MultiTenantEmployeeProvider {
+    fn indexes(&self) -> Result<Vec<Arc<dyn Index + 'static>>, DataFusionError> {
+        Ok(vec![self.age_index.clone(), self.dept_index.clone()])
+    }
+
+    fn union_mode(&self) -> UnionMode {
+        self.union_mode
+    }
+}

--- a/tests/common/employee_provider.rs
+++ b/tests/common/employee_provider.rs
@@ -76,6 +76,7 @@ impl EmployeeTableProvider {
     }
 
     /// Set the union mode for OR condition handling.
+    #[allow(dead_code)]
     pub fn with_union_mode(mut self, mode: UnionMode) -> Self {
         self.union_mode = mode;
         self

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,13 +1,18 @@
+#![allow(dead_code)]
+
 pub mod age_index;
+pub mod composite_pk_age_index;
+pub mod composite_pk_department_index;
+pub mod composite_pk_fetcher;
+pub mod composite_pk_provider;
 pub mod department_index;
 pub mod employee_provider;
 pub mod record_fetcher;
 
-use datafusion::arrow::array::{Int32Array, RecordBatch, StringArray};
+use composite_pk_provider::MultiTenantEmployeeProvider;
 use datafusion::execution::context::SessionContext;
 use datafusion_index_provider::types::UnionMode;
 use employee_provider::EmployeeTableProvider;
-use std::collections::HashSet;
 use std::sync::Arc;
 
 /// Helper function to setup test environment with parallel union mode (default).
@@ -35,108 +40,22 @@ async fn setup_test_env_with_mode(mode: UnionMode) -> SessionContext {
     ctx
 }
 
-pub fn assert_names(results: &[RecordBatch], expected_names: &[&str]) {
-    let mut names = HashSet::new();
-    for batch in results {
-        let name_batch = batch
-            .column(1) // name is first in projection
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        for name in name_batch.iter().flatten() {
-            names.insert(name.to_string());
-        }
-    }
-
-    for expected_name in expected_names {
-        assert!(
-            names.contains(*expected_name),
-            "Name {expected_name} not found in {names:?}"
-        );
-    }
-    assert_eq!(
-        names.len(),
-        expected_names.len(),
-        "Expected {} names: {:?}, got {} names: {:?}",
-        expected_names.len(),
-        expected_names,
-        names.len(),
-        names
-    );
+/// Helper function to setup composite PK test environment with parallel union mode (default).
+pub async fn setup_composite_pk_test_env() -> SessionContext {
+    setup_composite_pk_test_env_with_mode(UnionMode::Parallel).await
 }
 
-pub fn assert_ages(results: &[RecordBatch], expected_ages: &[i32]) {
-    let mut ages = HashSet::new();
-    for batch in results {
-        let age_batch = batch
-            .column(2) // age is second in projection
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .unwrap();
-        for age in age_batch.iter().flatten() {
-            ages.insert(age.to_string());
-        }
-    }
+/// Helper function to setup composite PK test environment with a specific union mode.
+async fn setup_composite_pk_test_env_with_mode(mode: UnionMode) -> SessionContext {
+    let _ = env_logger::builder()
+        .filter_level(log::LevelFilter::Debug)
+        .is_test(true)
+        .try_init();
 
-    for expected_age in expected_ages {
-        assert!(
-            ages.contains(&expected_age.to_string()),
-            "Age {expected_age} not found in {ages:?}"
-        );
-    }
-    assert_eq!(
-        ages.len(),
-        expected_ages.len(),
-        "Expected {} ages: {:?}, got {} ages: {:?}",
-        expected_ages.len(),
-        expected_ages,
-        ages.len(),
-        ages
-    );
-}
+    let ctx = SessionContext::new();
 
-pub fn assert_departments(results: &[RecordBatch], expected_departments: &[&str]) {
-    let mut departments = HashSet::new();
-    for batch in results {
-        let dept_batch = batch
-            .column(3) // department is third in projection
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        for dept in dept_batch.iter().flatten() {
-            departments.insert(dept.to_string());
-        }
-    }
+    let provider = MultiTenantEmployeeProvider::new().with_union_mode(mode);
+    ctx.register_table("employees", Arc::new(provider)).unwrap();
 
-    for expected_dept in expected_departments {
-        assert!(
-            departments.contains(*expected_dept),
-            "Department {expected_dept} not found in {departments:?}"
-        );
-    }
-    assert_eq!(
-        departments.len(),
-        expected_departments.len(),
-        "Expected {} departments: {:?}, got {} departments: {:?}",
-        expected_departments.len(),
-        expected_departments,
-        departments.len(),
-        departments
-    );
-}
-
-pub fn extract_names(results: &[RecordBatch]) -> Vec<String> {
-    let mut names = Vec::new();
-    for batch in results {
-        let name_batch = batch
-            .column(1) // name is first in projection
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        for name in name_batch.iter().flatten() {
-            names.push(name.to_string());
-        }
-    }
-    names.sort();
-    names
+    ctx
 }

--- a/tests/composite_pk_tests.rs
+++ b/tests/composite_pk_tests.rs
@@ -1,0 +1,213 @@
+//! Integration tests for composite primary key support.
+//!
+//! These tests validate that the index provider correctly handles primary keys
+//! composed of multiple columns (e.g., `(tenant_id, employee_id)`).
+
+mod common;
+
+use common::setup_composite_pk_test_env;
+use datafusion_common::assert_batches_sorted_eq;
+
+// Multi-tenant employee table with composite PK (tenant_id, employee_id):
+//
+// | tenant_id | employee_id | name    | age | department  |
+// |-----------|-------------|---------|-----|-------------|
+// | acme      | 1           | Alice   | 25  | Engineering |
+// | acme      | 2           | Bob     | 30  | Sales       |
+// | acme      | 3           | Charlie | 35  | Marketing   |
+// | globex    | 1           | David   | 28  | Engineering |
+// | globex    | 2           | Eve     | 32  | Sales       |
+
+#[tokio::test]
+async fn test_composite_pk_single_index_scan() {
+    let ctx = setup_composite_pk_test_env().await;
+
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age = 30")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    assert_batches_sorted_eq!(
+        [
+            "+-----------+-------------+------+-----+------------+",
+            "| tenant_id | employee_id | name | age | department |",
+            "+-----------+-------------+------+-----+------------+",
+            "| acme      | 2           | Bob  | 30  | Sales      |",
+            "+-----------+-------------+------+-----+------------+",
+        ],
+        &results
+    );
+}
+
+#[tokio::test]
+async fn test_composite_pk_single_index_range() {
+    let ctx = setup_composite_pk_test_env().await;
+
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age > 30")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    assert_batches_sorted_eq!(
+        [
+            "+-----------+-------------+---------+-----+------------+",
+            "| tenant_id | employee_id | name    | age | department |",
+            "+-----------+-------------+---------+-----+------------+",
+            "| acme      | 3           | Charlie | 35  | Marketing  |",
+            "| globex    | 2           | Eve     | 32  | Sales      |",
+            "+-----------+-------------+---------+-----+------------+",
+        ],
+        &results
+    );
+}
+
+#[tokio::test]
+async fn test_composite_pk_and_intersection() {
+    // age <= 30 AND department = 'Engineering'
+    // age <= 30: Alice(acme,1), Bob(acme,2), David(globex,1)
+    // Engineering: Alice(acme,1), David(globex,1)
+    // Intersection: Alice, David
+    let ctx = setup_composite_pk_test_env().await;
+
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age <= 30 AND department = 'Engineering'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    assert_batches_sorted_eq!(
+        [
+            "+-----------+-------------+-------+-----+-------------+",
+            "| tenant_id | employee_id | name  | age | department  |",
+            "+-----------+-------------+-------+-----+-------------+",
+            "| acme      | 1           | Alice | 25  | Engineering |",
+            "| globex    | 1           | David | 28  | Engineering |",
+            "+-----------+-------------+-------+-----+-------------+",
+        ],
+        &results
+    );
+}
+
+#[tokio::test]
+async fn test_composite_pk_or_deduplication() {
+    // age <= 25 OR department = 'Engineering'
+    // age <= 25: Alice(acme,1)
+    // Engineering: Alice(acme,1), David(globex,1)
+    // Union (deduped): Alice, David
+    let ctx = setup_composite_pk_test_env().await;
+
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age <= 25 OR department = 'Engineering'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    assert_batches_sorted_eq!(
+        [
+            "+-----------+-------------+-------+-----+-------------+",
+            "| tenant_id | employee_id | name  | age | department  |",
+            "+-----------+-------------+-------+-----+-------------+",
+            "| acme      | 1           | Alice | 25  | Engineering |",
+            "| globex    | 1           | David | 28  | Engineering |",
+            "+-----------+-------------+-------+-----+-------------+",
+        ],
+        &results
+    );
+}
+
+#[tokio::test]
+async fn test_composite_pk_or_no_overlap() {
+    // department = 'Marketing' OR department = 'Sales'
+    // Marketing: Charlie(acme,3)
+    // Sales: Bob(acme,2), Eve(globex,2)
+    // No overlap, result: Bob, Charlie, Eve
+    let ctx = setup_composite_pk_test_env().await;
+
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE department = 'Marketing' OR department = 'Sales'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    assert_batches_sorted_eq!(
+        [
+            "+-----------+-------------+---------+-----+------------+",
+            "| tenant_id | employee_id | name    | age | department |",
+            "+-----------+-------------+---------+-----+------------+",
+            "| acme      | 2           | Bob     | 30  | Sales      |",
+            "| acme      | 3           | Charlie | 35  | Marketing  |",
+            "| globex    | 2           | Eve     | 32  | Sales      |",
+            "+-----------+-------------+---------+-----+------------+",
+        ],
+        &results
+    );
+}
+
+#[tokio::test]
+async fn test_composite_pk_same_employee_id_different_tenant() {
+    // Verify that (acme, 1) and (globex, 1) are treated as different rows.
+    // department = 'Engineering' returns both Alice and David who share employee_id=1
+    let ctx = setup_composite_pk_test_env().await;
+
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE department = 'Engineering'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    assert_batches_sorted_eq!(
+        [
+            "+-----------+-------------+-------+-----+-------------+",
+            "| tenant_id | employee_id | name  | age | department  |",
+            "+-----------+-------------+-------+-----+-------------+",
+            "| acme      | 1           | Alice | 25  | Engineering |",
+            "| globex    | 1           | David | 28  | Engineering |",
+            "+-----------+-------------+-------+-----+-------------+",
+        ],
+        &results
+    );
+}
+
+#[tokio::test]
+async fn test_composite_pk_complex_nested() {
+    // (age <= 25 AND department = 'Engineering') OR department = 'Sales'
+    // age <= 25 AND Engineering: Alice(acme,1)
+    // Sales: Bob(acme,2), Eve(globex,2)
+    // Result: Alice, Bob, Eve
+    let ctx = setup_composite_pk_test_env().await;
+
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE (age <= 25 AND department = 'Engineering') OR department = 'Sales'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    assert_batches_sorted_eq!(
+        [
+            "+-----------+-------------+-------+-----+-------------+",
+            "| tenant_id | employee_id | name  | age | department  |",
+            "+-----------+-------------+-------+-----+-------------+",
+            "| acme      | 1           | Alice | 25  | Engineering |",
+            "| acme      | 2           | Bob   | 30  | Sales       |",
+            "| globex    | 2           | Eve   | 32  | Sales       |",
+            "+-----------+-------------+-------+-----+-------------+",
+        ],
+        &results
+    );
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,42 +1,85 @@
 mod common;
-use crate::common::assert_names;
-use common::{
-    assert_ages, assert_departments, extract_names, setup_test_env, setup_test_env_sequential,
-};
 
-// +----+-------+--------+----------+
-// | id | name  | age    | department|
-// +----+-------+--------+----------+
-// | 1  | Alice | 25    | Engineering|
-// | 2  | Bob   | 30    | Sales      |
-// | 3  |Charlie| 35    | Marketing  |
-// | 4  | David | 28    | Engineering|
-// | 5  | Eve   | 32    | Sales      |
-// +----+-------+--------+----------+
+use common::{setup_test_env, setup_test_env_sequential};
+use datafusion_common::assert_batches_sorted_eq;
+
+// +----+---------+-----+-------------+
+// | id | name    | age | department  |
+// +----+---------+-----+-------------+
+// | 1  | Alice   | 25  | Engineering |
+// | 2  | Bob     | 30  | Sales       |
+// | 3  | Charlie | 35  | Marketing   |
+// | 4  | David   | 28  | Engineering |
+// | 5  | Eve     | 32  | Sales       |
+// +----+---------+-----+-------------+
 
 #[tokio::test]
 async fn test_employee_table_filter_age_equal() {
-    // create a loop with tuples containing age and name to test equality
-    let test_cases = vec![
-        (25, "Alice"),
-        (30, "Bob"),
-        (35, "Charlie"),
-        (28, "David"),
-        (32, "Eve"),
+    let test_cases: Vec<(i32, &[&str])> = vec![
+        (
+            25,
+            &[
+                "+----+-------+-----+-------------+",
+                "| id | name  | age | department  |",
+                "+----+-------+-----+-------------+",
+                "| 1  | Alice | 25  | Engineering |",
+                "+----+-------+-----+-------------+",
+            ],
+        ),
+        (
+            30,
+            &[
+                "+----+------+-----+------------+",
+                "| id | name | age | department |",
+                "+----+------+-----+------------+",
+                "| 2  | Bob  | 30  | Sales      |",
+                "+----+------+-----+------------+",
+            ],
+        ),
+        (
+            35,
+            &[
+                "+----+---------+-----+------------+",
+                "| id | name    | age | department |",
+                "+----+---------+-----+------------+",
+                "| 3  | Charlie | 35  | Marketing  |",
+                "+----+---------+-----+------------+",
+            ],
+        ),
+        (
+            28,
+            &[
+                "+----+-------+-----+-------------+",
+                "| id | name  | age | department  |",
+                "+----+-------+-----+-------------+",
+                "| 4  | David | 28  | Engineering |",
+                "+----+-------+-----+-------------+",
+            ],
+        ),
+        (
+            32,
+            &[
+                "+----+------+-----+------------+",
+                "| id | name | age | department |",
+                "+----+------+-----+------------+",
+                "| 5  | Eve  | 32  | Sales      |",
+                "+----+------+-----+------------+",
+            ],
+        ),
     ];
 
-    for (age, name) in test_cases {
+    for (age, expected) in test_cases {
         let ctx = setup_test_env().await;
 
-        let df = ctx
-            .sql(&format!(
-                "SELECT name, age FROM employees WHERE age = {age}"
-            ))
+        let results = ctx
+            .sql(&format!("SELECT * FROM employees WHERE age = {age}"))
+            .await
+            .unwrap()
+            .collect()
             .await
             .unwrap();
-        let results = df.collect().await.unwrap();
-        assert_names(&results, &[name]);
-        assert_ages(&results, &[age]);
+
+        assert_batches_sorted_eq!(expected, &results);
     }
 }
 
@@ -44,515 +87,676 @@ async fn test_employee_table_filter_age_equal() {
 async fn test_employee_table_filter_age_gt() {
     let ctx = setup_test_env().await;
 
-    let df = ctx
-        .sql("SELECT name, age FROM employees WHERE age > 30")
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age > 30")
+        .await
+        .unwrap()
+        .collect()
         .await
         .unwrap();
-    let results = df.collect().await.unwrap();
-    assert_names(&results, &["Charlie", "Eve"]);
-    assert_ages(&results, &[35, 32]);
+
+    assert_batches_sorted_eq!(
+        [
+            "+----+---------+-----+------------+",
+            "| id | name    | age | department |",
+            "+----+---------+-----+------------+",
+            "| 3  | Charlie | 35  | Marketing  |",
+            "| 5  | Eve     | 32  | Sales      |",
+            "+----+---------+-----+------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_age_lt() {
     let ctx = setup_test_env().await;
 
-    let df = ctx
-        .sql("SELECT name, age FROM employees WHERE age < 30")
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age < 30")
+        .await
+        .unwrap()
+        .collect()
         .await
         .unwrap();
-    let results = df.collect().await.unwrap();
-    assert_names(&results, &["Alice", "David"]);
-    assert_ages(&results, &[25, 28]);
+
+    assert_batches_sorted_eq!(
+        [
+            "+----+-------+-----+-------------+",
+            "| id | name  | age | department  |",
+            "+----+-------+-----+-------------+",
+            "| 1  | Alice | 25  | Engineering |",
+            "| 4  | David | 28  | Engineering |",
+            "+----+-------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_department_equal() {
     let ctx = setup_test_env().await;
 
-    let df = ctx
-        .sql("SELECT name, age FROM employees WHERE department = 'Sales'")
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE department = 'Sales'")
+        .await
+        .unwrap()
+        .collect()
         .await
         .unwrap();
-    let results = df.collect().await.unwrap();
-    assert_names(&results, &["Bob", "Eve"]);
-    assert_ages(&results, &[30, 32]);
+
+    assert_batches_sorted_eq!(
+        [
+            "+----+------+-----+------------+",
+            "| id | name | age | department |",
+            "+----+------+-----+------------+",
+            "| 2  | Bob  | 30  | Sales      |",
+            "| 5  | Eve  | 32  | Sales      |",
+            "+----+------+-----+------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_age_and_department_no_result() {
     let ctx = setup_test_env().await;
 
-    let df = ctx
-        .sql("SELECT name, age FROM employees WHERE age > 30 AND department = 'Engineering'")
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age > 30 AND department = 'Engineering'")
+        .await
+        .unwrap()
+        .collect()
         .await
         .unwrap();
-    let results = df.collect().await.unwrap();
-    assert_names(&results, &[]);
-    assert_ages(&results, &[]);
+
+    let total_rows: usize = results.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 0);
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_age_and_department() {
     let ctx = setup_test_env().await;
 
-    let df = ctx
-        .sql("SELECT name, age FROM employees WHERE age <= 30 AND department = 'Engineering'")
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age <= 30 AND department = 'Engineering'")
+        .await
+        .unwrap()
+        .collect()
         .await
         .unwrap();
-    let results = df.collect().await.unwrap();
-    assert_names(&results, &["Alice", "David"]);
-    assert_ages(&results, &[25, 28]);
+
+    assert_batches_sorted_eq!(
+        [
+            "+----+-------+-----+-------------+",
+            "| id | name  | age | department  |",
+            "+----+-------+-----+-------------+",
+            "| 1  | Alice | 25  | Engineering |",
+            "| 4  | David | 28  | Engineering |",
+            "+----+-------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_age_or_department() {
     let ctx = setup_test_env().await;
 
-    let df = ctx
-        .sql("SELECT name, age FROM employees WHERE age <= 30 OR department = 'Engineering'")
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age <= 30 OR department = 'Engineering'")
+        .await
+        .unwrap()
+        .collect()
         .await
         .unwrap();
-    let results = df.collect().await.unwrap();
-    assert_names(&results, &["Alice", "Bob", "David"]);
-    assert_ages(&results, &[25, 30, 28]);
+
+    assert_batches_sorted_eq!(
+        [
+            "+----+-------+-----+-------------+",
+            "| id | name  | age | department  |",
+            "+----+-------+-----+-------------+",
+            "| 1  | Alice | 25  | Engineering |",
+            "| 2  | Bob   | 30  | Sales       |",
+            "| 4  | David | 28  | Engineering |",
+            "+----+-------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_multiple_or_on_age() {
     let ctx = setup_test_env().await;
 
-    let df = ctx
-        .sql("SELECT name, age FROM employees WHERE age = 25 OR age = 35 OR age = 32")
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age = 25 OR age = 35 OR age = 32")
+        .await
+        .unwrap()
+        .collect()
         .await
         .unwrap();
-    let results = df.collect().await.unwrap();
-    assert_names(&results, &["Alice", "Charlie", "Eve"]);
-    assert_ages(&results, &[25, 35, 32]);
+
+    assert_batches_sorted_eq!(
+        [
+            "+----+---------+-----+-------------+",
+            "| id | name    | age | department  |",
+            "+----+---------+-----+-------------+",
+            "| 1  | Alice   | 25  | Engineering |",
+            "| 3  | Charlie | 35  | Marketing   |",
+            "| 5  | Eve     | 32  | Sales       |",
+            "+----+---------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_multiple_or_on_age_unique() {
     let ctx = setup_test_env().await;
 
-    let df = ctx
-        .sql("SELECT name, age FROM employees WHERE age < 30 OR age > 30")
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age < 30 OR age > 30")
+        .await
+        .unwrap()
+        .collect()
         .await
         .unwrap();
-    let results = df.collect().await.unwrap();
-    assert_names(&results, &["Alice", "Charlie", "David", "Eve"]);
-    assert_ages(&results, &[25, 35, 28, 32]);
+
+    assert_batches_sorted_eq!(
+        [
+            "+----+---------+-----+-------------+",
+            "| id | name    | age | department  |",
+            "+----+---------+-----+-------------+",
+            "| 1  | Alice   | 25  | Engineering |",
+            "| 3  | Charlie | 35  | Marketing   |",
+            "| 4  | David   | 28  | Engineering |",
+            "| 5  | Eve     | 32  | Sales       |",
+            "+----+---------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_complex_query() {
     let ctx = setup_test_env().await;
 
-    let df = ctx
+    // (age < 30 AND department = 'Engineering') OR (age > 30 AND department = 'Sales')
+    // Alice(1,25,Eng), David(4,28,Eng) from first AND
+    // Eve(5,32,Sales) from second AND
+    let results = ctx
         .sql(
-            "SELECT name, age FROM employees WHERE (age < 30 AND department = 'Engineering') OR (age > 30 AND department = 'Sales')",
+            "SELECT * FROM employees WHERE (age < 30 AND department = 'Engineering') OR (age > 30 AND department = 'Sales')",
         )
         .await
+        .unwrap()
+        .collect()
+        .await
         .unwrap();
-    let results = df.collect().await.unwrap();
-    assert_names(&results, &["Alice", "David", "Eve"]);
-    assert_ages(&results, &[25, 28, 32]);
+
+    assert_batches_sorted_eq!(
+        [
+            "+----+-------+-----+-------------+",
+            "| id | name  | age | department  |",
+            "+----+-------+-----+-------------+",
+            "| 1  | Alice | 25  | Engineering |",
+            "| 4  | David | 28  | Engineering |",
+            "| 5  | Eve   | 32  | Sales       |",
+            "+----+-------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_or_with_overlapping_conditions() {
     let ctx = setup_test_env().await;
 
-    let df = ctx
-        .sql("SELECT name, age FROM employees WHERE age = 25 OR age < 29")
+    // age = 25 OR age < 29 → Alice(1,25,Eng), David(4,28,Eng) (deduped)
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age = 25 OR age < 29")
+        .await
+        .unwrap()
+        .collect()
         .await
         .unwrap();
-    let results = df.collect().await.unwrap();
 
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-    assert_eq!(
-        total_rows, 2,
-        "Expected 2 rows after deduplication, but found {total_rows}"
+    assert_batches_sorted_eq!(
+        [
+            "+----+-------+-----+-------------+",
+            "| id | name  | age | department  |",
+            "+----+-------+-----+-------------+",
+            "| 1  | Alice | 25  | Engineering |",
+            "| 4  | David | 28  | Engineering |",
+            "+----+-------+-----+-------------+",
+        ],
+        &results
     );
-
-    assert_names(&results, &["Alice", "David"]);
-    assert_ages(&results, &[25, 28]);
 }
 
-// Complex nested query test - demonstrating sophisticated AND/OR capabilities
 #[tokio::test]
 async fn test_employee_table_filter_extremely_complex_nested_query() {
     let ctx = setup_test_env().await;
 
-    // This demonstrates a sophisticated query with multiple AND conditions
-    // and strategic OR usage that works within current schema constraints
-    let df = ctx
+    // (age = 25 OR age = 28) AND department = 'Engineering' AND age < 40 AND age > 20
+    // → Alice(1,25,Eng), David(4,28,Eng)
+    let results = ctx
         .sql(
-            "SELECT name, age, department FROM employees WHERE 
-            (age = 25 OR age = 28) 
-            AND 
+            "SELECT * FROM employees WHERE
+            (age = 25 OR age = 28)
+            AND
             department = 'Engineering'
             AND
-            age < 40 
-            AND 
+            age < 40
+            AND
             age > 20",
         )
         .await
+        .unwrap()
+        .collect()
+        .await
         .unwrap();
 
-    let results = df.collect().await.unwrap();
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-
-    // This query should match Alice (25, Engineering) and David (28, Engineering)
-    assert_eq!(total_rows, 2, "Expected exactly 2 rows, got {total_rows}");
-
-    // Verify we get the expected employees
-    assert_names(&results, &["Alice", "David"]);
-    assert_ages(&results, &[25, 28]);
-
-    println!("Complex AND/OR query with precise filtering results: {results:?}");
+    assert_batches_sorted_eq!(
+        [
+            "+----+-------+-----+-------------+",
+            "| id | name  | age | department  |",
+            "+----+-------+-----+-------------+",
+            "| 1  | Alice | 25  | Engineering |",
+            "| 4  | David | 28  | Engineering |",
+            "+----+-------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_deeply_nested_and_or_combinations() {
     let ctx = setup_test_env().await;
 
-    // Another complex nested query focusing on AND combinations with OR subclauses
-    // This tests the index intersection capabilities with complex filter trees
-    let df = ctx
+    // ((age >= 25 AND age <= 30) AND (department = 'Engineering' OR department = 'Sales'))
+    // AND ((age != 27 AND age != 29) OR (department = 'Engineering' AND age < 29))
+    // → Alice(1,25,Eng), David(4,28,Eng)
+    let results = ctx
         .sql(
-            "SELECT name, age, department FROM employees WHERE 
+            "SELECT * FROM employees WHERE
             (
-                (age >= 25 AND age <= 30) 
-                AND 
+                (age >= 25 AND age <= 30)
+                AND
                 (department = 'Engineering' OR department = 'Sales')
             )
             AND
             (
-                (age != 27 AND age != 29) 
-                OR 
+                (age != 27 AND age != 29)
+                OR
                 (department = 'Engineering' AND age < 29)
             )",
         )
         .await
+        .unwrap()
+        .collect()
+        .await
         .unwrap();
 
-    let results = df.collect().await.unwrap();
-
-    // This should match employees in Engineering/Sales aged 25-30,
-    // excluding ages 27,29 unless they're in Engineering and under 29
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-    assert!(total_rows >= 1, "Expected at least 1 row, got {total_rows}");
-
-    // Should include Alice (25, Engineering) and David (28, Engineering)
-    assert_names(&results, &["Alice", "David"]);
-    assert_ages(&results, &[25, 28]);
+    assert_batches_sorted_eq!(
+        [
+            "+----+-------+-----+-------------+",
+            "| id | name  | age | department  |",
+            "+----+-------+-----+-------------+",
+            "| 1  | Alice | 25  | Engineering |",
+            "| 4  | David | 28  | Engineering |",
+            "+----+-------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_complex_and_or_mixed() {
     let ctx = setup_test_env().await;
 
-    // Complex query that previously caused UnionExec schema mismatch
-    // (age > 30 AND department = 'Engineering') creates HashJoinExec with 2 __row_id__ columns
-    // department = 'Sales' creates IndexScanExec with 1 __row_id__ column
-    // Our fix adds ProjectionExec to normalize schemas before UnionExec
-    let df = ctx
+    // (age > 30 AND department = 'Engineering') OR department = 'Sales'
+    // No Engineering employees > 30
+    // → Bob(2,30,Sales), Eve(5,32,Sales)
+    let results = ctx
         .sql(
-            "SELECT name, age, department FROM employees WHERE 
+            "SELECT * FROM employees WHERE
             (age > 30 AND department = 'Engineering') OR department = 'Sales'",
         )
         .await
+        .unwrap()
+        .collect()
+        .await
         .unwrap();
 
-    let results = df.collect().await.unwrap();
-
-    // Should return:
-    // - No one from the AND condition (no Engineering employees > 30)
-    // - Bob (30, Sales) and Eve (32, Sales) from the OR condition
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-    assert_eq!(total_rows, 2, "Expected 2 rows, got {total_rows}");
-
-    assert_names(&results, &["Bob", "Eve"]);
-    assert_ages(&results, &[30, 32]);
-    assert_departments(&results, &["Sales"]);
+    assert_batches_sorted_eq!(
+        [
+            "+----+------+-----+------------+",
+            "| id | name | age | department |",
+            "+----+------+-----+------------+",
+            "| 2  | Bob  | 30  | Sales      |",
+            "| 5  | Eve  | 32  | Sales      |",
+            "+----+------+-----+------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_multiple_and_conditions_in_or() {
     let ctx = setup_test_env().await;
 
-    // Multiple AND conditions within OR - all creating HashJoinExec plans
-    let df = ctx
+    // (age >= 25 AND department = 'Engineering') OR (age >= 30 AND department = 'Sales')
+    // → Alice(1,25,Eng), David(4,28,Eng), Bob(2,30,Sales), Eve(5,32,Sales)
+    let results = ctx
         .sql(
-            "SELECT name, age, department FROM employees WHERE 
-            (age >= 25 AND department = 'Engineering') OR 
+            "SELECT * FROM employees WHERE
+            (age >= 25 AND department = 'Engineering') OR
             (age >= 30 AND department = 'Sales')",
         )
         .await
+        .unwrap()
+        .collect()
+        .await
         .unwrap();
 
-    let results = df.collect().await.unwrap();
-
-    // Should return:
-    // - Alice (25, Engineering) and David (28, Engineering) from first AND
-    // - Bob (30, Sales) and Eve (32, Sales) from second AND
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-    assert_eq!(total_rows, 4, "Expected 4 rows, got {total_rows}");
-
-    assert_names(&results, &["Alice", "Bob", "David", "Eve"]);
-    assert_ages(&results, &[25, 30, 28, 32]);
-    assert_departments(&results, &["Engineering", "Sales"]);
+    assert_batches_sorted_eq!(
+        [
+            "+----+-------+-----+-------------+",
+            "| id | name  | age | department  |",
+            "+----+-------+-----+-------------+",
+            "| 1  | Alice | 25  | Engineering |",
+            "| 2  | Bob   | 30  | Sales       |",
+            "| 4  | David | 28  | Engineering |",
+            "| 5  | Eve   | 32  | Sales       |",
+            "+----+-------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_and_or_with_simple_conditions() {
     let ctx = setup_test_env().await;
 
-    // Mix of AND condition and simple OR conditions
-    let df = ctx
+    // (age < 28 AND department = 'Engineering') OR department = 'Sales' OR age = 28
+    // → Alice(1,25,Eng), Bob(2,30,Sales), David(4,28,Eng), Eve(5,32,Sales)
+    let results = ctx
         .sql(
-            "SELECT name, age FROM employees WHERE 
-            (age < 28 AND department = 'Engineering') OR 
-            department = 'Sales' OR 
+            "SELECT * FROM employees WHERE
+            (age < 28 AND department = 'Engineering') OR
+            department = 'Sales' OR
             age = 28",
         )
         .await
+        .unwrap()
+        .collect()
+        .await
         .unwrap();
 
-    let results = df.collect().await.unwrap();
-
-    // Should return:
-    // - Alice (25, Engineering) from the AND condition
-    // - Bob (30, Sales) and Eve (32, Sales) from department = 'Sales'
-    // - David (28, Engineering) from age = 28
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-    assert_eq!(total_rows, 4, "Expected 4 rows, got {total_rows}");
-
-    assert_names(&results, &["Alice", "Bob", "David", "Eve"]);
-    assert_ages(&results, &[25, 30, 28, 32]);
-    // Note: Only projecting name, age columns in this test
+    assert_batches_sorted_eq!(
+        [
+            "+----+-------+-----+-------------+",
+            "| id | name  | age | department  |",
+            "+----+-------+-----+-------------+",
+            "| 1  | Alice | 25  | Engineering |",
+            "| 2  | Bob   | 30  | Sales       |",
+            "| 4  | David | 28  | Engineering |",
+            "| 5  | Eve   | 32  | Sales       |",
+            "+----+-------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_nested_and_or_schema_normalization() {
     let ctx = setup_test_env().await;
 
-    // Very complex nested query that creates multiple schema types
-    let df = ctx
+    // ((age > 25 AND age < 35) AND department = 'Engineering') OR (department = 'Sales' OR department = 'Marketing')
+    // → David(4,28,Eng), Bob(2,30,Sales), Charlie(3,35,Marketing), Eve(5,32,Sales)
+    let results = ctx
         .sql(
-            "SELECT name, department FROM employees WHERE 
-            ((age > 25 AND age < 35) AND department = 'Engineering') OR 
+            "SELECT * FROM employees WHERE
+            ((age > 25 AND age < 35) AND department = 'Engineering') OR
             (department = 'Sales' OR department = 'Marketing')",
         )
         .await
+        .unwrap()
+        .collect()
+        .await
         .unwrap();
 
-    let results = df.collect().await.unwrap();
-
-    // Should return David (28, Engineering) and Charlie (35, Marketing), Bob (30, Sales), Eve (32, Sales)
-    // From: ((age > 25 AND age < 35) AND department = 'Engineering') OR (department = 'Sales' OR department = 'Marketing')
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-    assert_eq!(total_rows, 4, "Expected 4 rows, got {total_rows}");
-
-    assert_names(&results, &["Bob", "Charlie", "David", "Eve"]);
-    assert_departments(&results, &["Engineering", "Marketing", "Sales"]);
+    assert_batches_sorted_eq!(
+        [
+            "+----+---------+-----+-------------+",
+            "| id | name    | age | department  |",
+            "+----+---------+-----+-------------+",
+            "| 2  | Bob     | 30  | Sales       |",
+            "| 3  | Charlie | 35  | Marketing   |",
+            "| 4  | David   | 28  | Engineering |",
+            "| 5  | Eve     | 32  | Sales       |",
+            "+----+---------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_triple_or_with_and_conditions() {
     let ctx = setup_test_env().await;
 
-    // Three-way OR with different complexity levels
-    let df = ctx
+    // (age = 25 AND department = 'Engineering') OR (age > 30 AND department = 'Sales') OR department = 'Marketing'
+    // → Alice(1,25,Eng), Eve(5,32,Sales), Charlie(3,35,Marketing)
+    let results = ctx
         .sql(
-            "SELECT name, age, department FROM employees WHERE 
-            (age = 25 AND department = 'Engineering') OR 
-            (age > 30 AND department = 'Sales') OR 
+            "SELECT * FROM employees WHERE
+            (age = 25 AND department = 'Engineering') OR
+            (age > 30 AND department = 'Sales') OR
             department = 'Marketing'",
         )
         .await
+        .unwrap()
+        .collect()
+        .await
         .unwrap();
 
-    let results = df.collect().await.unwrap();
-
-    // Should return:
-    // - Alice (25, Engineering) from (age = 25 AND department = 'Engineering')
-    // - Eve (32, Sales) from (age > 30 AND department = 'Sales') - Bob is 30, not > 30
-    // - Charlie (35, Marketing) from department = 'Marketing'
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-    assert_eq!(total_rows, 3, "Expected 3 rows, got {total_rows}");
-
-    assert_names(&results, &["Alice", "Charlie", "Eve"]);
-    assert_ages(&results, &[25, 35, 32]);
-    assert_departments(&results, &["Engineering", "Marketing", "Sales"]);
+    assert_batches_sorted_eq!(
+        [
+            "+----+---------+-----+-------------+",
+            "| id | name    | age | department  |",
+            "+----+---------+-----+-------------+",
+            "| 1  | Alice   | 25  | Engineering |",
+            "| 3  | Charlie | 35  | Marketing   |",
+            "| 5  | Eve     | 32  | Sales       |",
+            "+----+---------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_all_and_conditions_in_or() {
     let ctx = setup_test_env().await;
 
-    // All OR branches are AND conditions - all should create HashJoinExec
-    let df = ctx
+    // All OR branches are AND conditions
+    // → All 5 employees
+    let results = ctx
         .sql(
-            "SELECT name FROM employees WHERE 
-            (age >= 25 AND department = 'Engineering') OR 
+            "SELECT * FROM employees WHERE
+            (age >= 25 AND department = 'Engineering') OR
             (age >= 30 AND department = 'Sales') OR
             (age >= 28 AND department = 'Marketing')",
         )
         .await
+        .unwrap()
+        .collect()
+        .await
         .unwrap();
 
-    let results = df.collect().await.unwrap();
-
-    // Should return:
-    // - Alice (25, Engineering) and David (28, Engineering) from (age >= 25 AND department = 'Engineering')
-    // - Bob (30, Sales) and Eve (32, Sales) from (age >= 30 AND department = 'Sales')
-    // - Charlie (35, Marketing) from (age >= 28 AND department = 'Marketing')
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-    assert_eq!(total_rows, 5, "Expected 5 rows, got {total_rows}");
-
-    assert_names(&results, &["Alice", "Bob", "Charlie", "David", "Eve"]);
+    assert_batches_sorted_eq!(
+        [
+            "+----+---------+-----+-------------+",
+            "| id | name    | age | department  |",
+            "+----+---------+-----+-------------+",
+            "| 1  | Alice   | 25  | Engineering |",
+            "| 2  | Bob     | 30  | Sales       |",
+            "| 3  | Charlie | 35  | Marketing   |",
+            "| 4  | David   | 28  | Engineering |",
+            "| 5  | Eve     | 32  | Sales       |",
+            "+----+---------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_complex_and_or_deduplication() {
     let ctx = setup_test_env().await;
 
-    // Query that might return overlapping results - test deduplication
-    let df = ctx
+    // (age >= 30 AND department = 'Engineering') OR (department = 'Engineering' AND age > 25)
+    // → David(4,28,Eng) only
+    let results = ctx
         .sql(
-            "SELECT name, age, department FROM employees WHERE 
-            (age >= 30 AND department = 'Engineering') OR 
+            "SELECT * FROM employees WHERE
+            (age >= 30 AND department = 'Engineering') OR
             (department = 'Engineering' AND age > 25)",
         )
         .await
+        .unwrap()
+        .collect()
+        .await
         .unwrap();
 
-    let results = df.collect().await.unwrap();
-
-    // Query: (age >= 30 AND department = 'Engineering') OR (department = 'Engineering' AND age > 25)
-    // Only David (28, Engineering) matches both branches
-    // Alice (25, Engineering) matches the second branch but not the first (age < 30)
-    // However both branches are for Engineering, so Alice matches the second branch
-    // Wait, let me check the logs again...actually only David (row_id 4) was returned
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-    assert_eq!(total_rows, 1, "Expected 1 row, got {total_rows}");
-
-    assert_names(&results, &["David"]);
-    assert_ages(&results, &[28]);
-    assert_departments(&results, &["Engineering"]);
-
-    // Verify no duplicate names (proper deduplication)
-    let names = extract_names(&results);
-    let unique_names: std::collections::HashSet<_> = names.iter().collect();
-    assert_eq!(names.len(), unique_names.len(), "Found duplicate results");
+    assert_batches_sorted_eq!(
+        [
+            "+----+-------+-----+-------------+",
+            "| id | name  | age | department  |",
+            "+----+-------+-----+-------------+",
+            "| 4  | David | 28  | Engineering |",
+            "+----+-------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_four_way_or_schema_stress_test() {
     let ctx = setup_test_env().await;
 
-    // Four-way OR with maximum schema diversity to stress test normalization
-    let df = ctx
+    // Four-way OR → all 5 employees
+    let results = ctx
         .sql(
-            "SELECT name FROM employees WHERE 
-            (age = 25 AND department = 'Engineering') OR 
+            "SELECT * FROM employees WHERE
+            (age = 25 AND department = 'Engineering') OR
             (age >= 30 AND department = 'Sales') OR
             department = 'Marketing' OR
             age = 28",
         )
         .await
+        .unwrap()
+        .collect()
+        .await
         .unwrap();
 
-    let results = df.collect().await.unwrap();
-
-    // Should return:
-    // - Alice (25, Engineering) from (age = 25 AND department = 'Engineering')
-    // - Bob (30, Sales) and Eve (32, Sales) from (age >= 30 AND department = 'Sales')
-    // - Charlie (35, Marketing) from department = 'Marketing'
-    // - David (28, Engineering) from age = 28
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-    assert_eq!(total_rows, 5, "Expected 5 rows, got {total_rows}");
-
-    assert_names(&results, &["Alice", "Bob", "Charlie", "David", "Eve"]);
+    assert_batches_sorted_eq!(
+        [
+            "+----+---------+-----+-------------+",
+            "| id | name    | age | department  |",
+            "+----+---------+-----+-------------+",
+            "| 1  | Alice   | 25  | Engineering |",
+            "| 2  | Bob     | 30  | Sales       |",
+            "| 3  | Charlie | 35  | Marketing   |",
+            "| 4  | David   | 28  | Engineering |",
+            "| 5  | Eve     | 32  | Sales       |",
+            "+----+---------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_deeply_nested_and_or_schema_normalization() {
     let ctx = setup_test_env().await;
 
-    // Deeply nested query with multiple levels of AND/OR
-    let df = ctx
+    // ((age > 25 AND age < 30) OR (age > 30 AND age < 35)) AND (department = 'Engineering' OR department = 'Sales')
+    // → David(4,28,Eng), Eve(5,32,Sales)
+    let results = ctx
         .sql(
-            "SELECT name, age FROM employees WHERE 
-            ((age > 25 AND age < 30) OR (age > 30 AND age < 35)) AND 
+            "SELECT * FROM employees WHERE
+            ((age > 25 AND age < 30) OR (age > 30 AND age < 35)) AND
             (department = 'Engineering' OR department = 'Sales')",
         )
         .await
+        .unwrap()
+        .collect()
+        .await
         .unwrap();
 
-    let results = df.collect().await.unwrap();
-
-    // Query: ((age > 25 AND age < 30) OR (age > 30 AND age < 35)) AND (department = 'Engineering' OR department = 'Sales')
-    // This simplifies to: (age 26-29 OR age 31-34) AND (Engineering OR Sales)
-    // Results: David (28, Engineering) and Eve (32, Sales)
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-    assert_eq!(total_rows, 2, "Expected 2 rows, got {total_rows}");
-
-    assert_names(&results, &["David", "Eve"]);
-    assert_ages(&results, &[28, 32]);
+    assert_batches_sorted_eq!(
+        [
+            "+----+-------+-----+-------------+",
+            "| id | name  | age | department  |",
+            "+----+-------+-----+-------------+",
+            "| 4  | David | 28  | Engineering |",
+            "| 5  | Eve   | 32  | Sales       |",
+            "+----+-------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_edge_case_single_and_in_or() {
     let ctx = setup_test_env().await;
 
-    // Edge case: single AND condition should work without UnionExec
-    let df = ctx
-        .sql(
-            "SELECT name, department FROM employees WHERE 
-            age > 30 AND department = 'Engineering'",
-        )
+    // age > 30 AND department = 'Engineering' → no results
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age > 30 AND department = 'Engineering'")
+        .await
+        .unwrap()
+        .collect()
         .await
         .unwrap();
 
-    let results = df.collect().await.unwrap();
-
-    // Should return no one (Charlie is in Marketing, not Engineering, and no Engineering employees > 30)
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-    assert_eq!(total_rows, 0, "Expected 0 rows, got {total_rows}");
+    let total_rows: usize = results.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 0);
 }
 
 #[tokio::test]
 async fn test_employee_table_filter_all_simple_or_conditions() {
     let ctx = setup_test_env().await;
 
-    // All simple conditions - should all create IndexScanExec with same schema
-    let df = ctx
+    // department = 'Engineering' OR department = 'Sales' OR age = 25 OR age = 32
+    // → Alice(1,25,Eng), Bob(2,30,Sales), David(4,28,Eng), Eve(5,32,Sales) (deduped)
+    let results = ctx
         .sql(
-            "SELECT name, age FROM employees WHERE 
-            department = 'Engineering' OR 
-            department = 'Sales' OR 
-            age = 25 OR 
+            "SELECT * FROM employees WHERE
+            department = 'Engineering' OR
+            department = 'Sales' OR
+            age = 25 OR
             age = 32",
         )
         .await
+        .unwrap()
+        .collect()
+        .await
         .unwrap();
 
-    let results = df.collect().await.unwrap();
-
-    // Should return:
-    // - Alice (25, Engineering) and David (28, Engineering) from department = 'Engineering'
-    // - Bob (30, Sales) and Eve (32, Sales) from department = 'Sales'
-    // - Alice (25) again from age = 25
-    // - Eve (32) again from age = 32
-    // But deduplication should give us: Alice, Bob, David, Eve
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-    assert_eq!(total_rows, 4, "Expected 4 rows, got {total_rows}");
-
-    assert_names(&results, &["Alice", "Bob", "David", "Eve"]);
-    assert_ages(&results, &[25, 30, 28, 32]);
+    assert_batches_sorted_eq!(
+        [
+            "+----+-------+-----+-------------+",
+            "| id | name  | age | department  |",
+            "+----+-------+-----+-------------+",
+            "| 1  | Alice | 25  | Engineering |",
+            "| 2  | Bob   | 30  | Sales       |",
+            "| 4  | David | 28  | Engineering |",
+            "| 5  | Eve   | 32  | Sales       |",
+            "+----+-------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 // =============================================================================
@@ -565,91 +769,134 @@ async fn test_employee_table_filter_all_simple_or_conditions() {
 async fn test_sequential_union_mode_simple_or() {
     let ctx = setup_test_env_sequential().await;
 
-    // Simple OR query that triggers SequentialUnionExec
-    let df = ctx
-        .sql("SELECT name, age FROM employees WHERE age = 25 OR age = 35")
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age = 25 OR age = 35")
+        .await
+        .unwrap()
+        .collect()
         .await
         .unwrap();
-    let results = df.collect().await.unwrap();
 
-    assert_names(&results, &["Alice", "Charlie"]);
-    assert_ages(&results, &[25, 35]);
+    assert_batches_sorted_eq!(
+        [
+            "+----+---------+-----+-------------+",
+            "| id | name    | age | department  |",
+            "+----+---------+-----+-------------+",
+            "| 1  | Alice   | 25  | Engineering |",
+            "| 3  | Charlie | 35  | Marketing   |",
+            "+----+---------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_sequential_union_mode_multiple_or() {
     let ctx = setup_test_env_sequential().await;
 
-    // Multiple OR conditions
-    let df = ctx
-        .sql("SELECT name, age FROM employees WHERE age = 25 OR age = 30 OR age = 35")
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age = 25 OR age = 30 OR age = 35")
+        .await
+        .unwrap()
+        .collect()
         .await
         .unwrap();
-    let results = df.collect().await.unwrap();
 
-    assert_names(&results, &["Alice", "Bob", "Charlie"]);
-    assert_ages(&results, &[25, 30, 35]);
+    assert_batches_sorted_eq!(
+        [
+            "+----+---------+-----+-------------+",
+            "| id | name    | age | department  |",
+            "+----+---------+-----+-------------+",
+            "| 1  | Alice   | 25  | Engineering |",
+            "| 2  | Bob     | 30  | Sales       |",
+            "| 3  | Charlie | 35  | Marketing   |",
+            "+----+---------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_sequential_union_mode_mixed_indexes() {
     let ctx = setup_test_env_sequential().await;
 
-    // OR across different indexes (age and department)
-    let df = ctx
-        .sql("SELECT name, age FROM employees WHERE age = 25 OR department = 'Sales'")
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age = 25 OR department = 'Sales'")
+        .await
+        .unwrap()
+        .collect()
         .await
         .unwrap();
-    let results = df.collect().await.unwrap();
 
-    assert_names(&results, &["Alice", "Bob", "Eve"]);
-    assert_ages(&results, &[25, 30, 32]);
+    assert_batches_sorted_eq!(
+        [
+            "+----+-------+-----+-------------+",
+            "| id | name  | age | department  |",
+            "+----+-------+-----+-------------+",
+            "| 1  | Alice | 25  | Engineering |",
+            "| 2  | Bob   | 30  | Sales       |",
+            "| 5  | Eve   | 32  | Sales       |",
+            "+----+-------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_sequential_union_mode_complex_and_or() {
     let ctx = setup_test_env_sequential().await;
 
-    // Complex query with AND conditions inside OR - tests schema normalization
-    let df = ctx
+    // (age >= 25 AND department = 'Engineering') OR (age >= 30 AND department = 'Sales')
+    // → Alice(1,25,Eng), David(4,28,Eng), Bob(2,30,Sales), Eve(5,32,Sales)
+    let results = ctx
         .sql(
-            "SELECT name, age, department FROM employees WHERE
+            "SELECT * FROM employees WHERE
             (age >= 25 AND department = 'Engineering') OR
             (age >= 30 AND department = 'Sales')",
         )
         .await
+        .unwrap()
+        .collect()
+        .await
         .unwrap();
-    let results = df.collect().await.unwrap();
 
-    // Should return:
-    // - Alice (25, Engineering) and David (28, Engineering) from first AND
-    // - Bob (30, Sales) and Eve (32, Sales) from second AND
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-    assert_eq!(total_rows, 4, "Expected 4 rows, got {total_rows}");
-
-    assert_names(&results, &["Alice", "Bob", "David", "Eve"]);
-    assert_ages(&results, &[25, 30, 28, 32]);
-    assert_departments(&results, &["Engineering", "Sales"]);
+    assert_batches_sorted_eq!(
+        [
+            "+----+-------+-----+-------------+",
+            "| id | name  | age | department  |",
+            "+----+-------+-----+-------------+",
+            "| 1  | Alice | 25  | Engineering |",
+            "| 2  | Bob   | 30  | Sales       |",
+            "| 4  | David | 28  | Engineering |",
+            "| 5  | Eve   | 32  | Sales       |",
+            "+----+-------+-----+-------------+",
+        ],
+        &results
+    );
 }
 
 #[tokio::test]
 async fn test_sequential_union_mode_deduplication() {
     let ctx = setup_test_env_sequential().await;
 
-    // Query with overlapping conditions - tests that deduplication works
-    let df = ctx
-        .sql("SELECT name, age FROM employees WHERE age = 25 OR age < 29")
+    // age = 25 OR age < 29 → Alice(1,25,Eng), David(4,28,Eng) (deduped)
+    let results = ctx
+        .sql("SELECT * FROM employees WHERE age = 25 OR age < 29")
+        .await
+        .unwrap()
+        .collect()
         .await
         .unwrap();
-    let results = df.collect().await.unwrap();
 
-    // Alice (25) matches both conditions, should appear only once
-    let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
-    assert_eq!(
-        total_rows, 2,
-        "Expected 2 rows after deduplication, got {total_rows}"
+    assert_batches_sorted_eq!(
+        [
+            "+----+-------+-----+-------------+",
+            "| id | name  | age | department  |",
+            "+----+-------+-----+-------------+",
+            "| 1  | Alice | 25  | Engineering |",
+            "| 4  | David | 28  | Engineering |",
+            "+----+-------+-----+-------------+",
+        ],
+        &results
     );
-
-    assert_names(&results, &["Alice", "David"]);
-    assert_ages(&results, &[25, 28]);
 }


### PR DESCRIPTION
Replace the single-column `__row_id__` design with composite primary key support. All columns in `Index::index_schema()` are now treated as the composite primary key, enabling multi-column key lookups.

Key changes:
- `create_index_schema()` accepts `impl IntoIterator<Item = Field>`
- `create_plan_properties_for_pk_scan()` replaces row_id-specific variant
- AND joins operate on all PK columns with Projection to deduplicate
- OR dedup uses `GROUP BY` on all PK columns
- Return proper errors instead of silent fallbacks in join column lookup
- Use full Field equality in `project_to_pk_schema()`
- Align README and rustdoc with composite PK terminology
- Fix unresolved `UnionExec` rustdoc links
- Suppress false-positive dead_code warnings in shared test helpers
- Add composite PK integration tests with multi-tenant example